### PR TITLE
Configuração do Contexto de Banco - AppDbContext

### DIFF
--- a/SabidosAPI-Core/Data/AppDbContext.cs
+++ b/SabidosAPI-Core/Data/AppDbContext.cs
@@ -1,0 +1,22 @@
+using FirebaseJwtApi.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace SabidosAPI_Core.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<User> Users => Set<User>();
+    public DbSet<Resumo> Resumos => Set<Post>();
+    public DbSet<Evento> Eventos => Set<Post>();
+    public DbSet<Pomodoro> Pomodoros => Set<Post>();
+    public DbSet<Flashcard> Flashcards => Set<Post>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<User>().HasIndex(u => u.FirebaseUid).IsUnique();
+        base.OnModelCreating(modelBuilder);
+    }
+}
+  


### PR DESCRIPTION
#11
Implementa AppDbContext com DbSets e índice único

Adicionadas novas importações e implementada a classe `AppDbContext`, que herda de `DbContext`. Definidas propriedades `DbSet` para as entidades `User`, `Resumo`, `Evento`, `Pomodoro` e `Flashcard`. Configurado índice único para o campo `FirebaseUid` na entidade `User` no método `OnModelCreating`.