### PR TITLE
Estrutura de Testes APi.Test (xUnit) e adição de Dependencias( xUnit + EF InMemory )#26

### DIFF
--- a/SabidosAPI-Core/Api.Tests/Api.Tests.csproj
+++ b/SabidosAPI-Core/Api.Tests/Api.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SabidosAPI-Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SabidosAPI-Core/Api.Tests/UnitTest1.cs
+++ b/SabidosAPI-Core/Api.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace Api.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}


### PR DESCRIPTION
Adicionar configuração de testes com xUnit e Coverlet

Criação do arquivo `Api.Tests.csproj` com configuração para o SDK do .NET, definindo o framework como `net9.0`, habilitando uso implícito de namespaces e verificação de nulidade. Foram adicionadas referências a pacotes de teste, incluindo `coverlet.collector`, `Microsoft.NET.Test.Sdk`, `xunit` e `xunit.runner.visualstudio`, além de uma referência ao projeto `SabidosAPI-Core.csproj`.

Criação do arquivo `UnitTest1.cs` com a classe de teste `UnitTest1`, que contém um método de teste vazio `Test1`, utilizando o atributo `[Fact]` do xUnit.