### PR TITLE
Mapear Dtos de User/ Usuario (AutoMapper) #21

### DIFF
--- a/SabidosAPI-Core/Mappings/UserProfile.cs
+++ b/SabidosAPI-Core/Mappings/UserProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using SabidosAPI_Core.DTOs;
+using SabidosAPI_Core.Models;
+
+namespace SabidosAPI_Core.Mappings;
+
+public class UserProfile : Profile
+{
+    public UserProfile()
+    {
+        CreateMap<User, UserResponseDto>();
+        CreateMap<UserUpdateDto, User>().ForAllMembers(opts => opts.Condition((src, dest, srcMember) => srcMember != null));
+    }
+}


### PR DESCRIPTION
Adiciona mapeamentos de usuário no AutoMapper

Foram adicionadas novas importações ao arquivo `UserProfile.cs`, incluindo `AutoMapper`, `SabidosAPI_Core.DTOs` e `SabidosAPI_Core.Models`. Foi criada a classe `UserProfile` que herda de `Profile`. Dentro do construtor, foram definidos mapeamentos para `User` e `UserUpdateDto`, com uma condição que ignora membros nulos.