### PR TITLE
HotFix :Remover referências à pasta "Mappings" no projeto

### DIFF
--- a/SabidosAPI-Core/SabidosAPI-Core.csproj
+++ b/SabidosAPI-Core/SabidosAPI-Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -11,9 +11,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Mappings\**" />
+    <Content Remove="Mappings\**" />
+    <EmbeddedResource Remove="Mappings\**" />
+    <None Remove="Mappings\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Remove="Data\AppDbContext.cs" />
     <Compile Remove="DTOs\UserResponseDto.cs" />
-    <Compile Remove="Mappings\UserProfile.cs" />
     <Compile Remove="Models\User.cs" />
     <Compile Remove="Services\UserService.cs" />
   </ItemGroup>
@@ -41,10 +47,6 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Mappings\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
O arquivo `SabidosAPI-Core.csproj` foi atualizado para eliminar todas as referências a arquivos e pastas relacionadas a "Mappings". Isso inclui a remoção da definição da pasta, a exclusão de arquivos da seção de compilação, conteúdo e recursos incorporados, além da remoção específica do arquivo `Mappings\UserProfile.cs`. Um novo grupo de itens foi adicionado para garantir que todos os arquivos da pasta "Mappings" sejam removidos.