### PR TITLE
FIX : namespaces e referências não reconhecidas #35

### DIFF
--- a/SabidosAPI-Core/Data/AppDbContext.cs
+++ b/SabidosAPI-Core/Data/AppDbContext.cs
@@ -1,4 +1,4 @@
-using FirebaseJwtApi.Models;
+using SabidosAPI_Core.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace SabidosAPI_Core.Data;

--- a/SabidosAPI-Core/SabidosAPI-Core.csproj
+++ b/SabidosAPI-Core/SabidosAPI-Core.csproj
@@ -11,33 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Data\AppDbContext.cs" />
-    <Compile Remove="DTOs\UserResponseDto.cs" />
-    <Compile Remove="Models\User.cs" />
-    <Compile Remove="Services\UserService.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="Data\AppDbContext.cs" />
-    <None Include="DTOs\UserResponseDto.cs" />
-    <None Include="Models\User.cs" />
-    <None Include="Services\UserService.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="15.0.1" />
+    <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
   </ItemGroup>


### PR DESCRIPTION
Refatoração de dependências e ajustes no contexto do DB

Atualizada a importação de modelos em `AppDbContext.cs` para `SabidosAPI_Core.Models`. Removidas referências de compilação não utilizadas no projeto. A versão do pacote `AutoMapper` foi alterada de `15.0.1` para `12.0.1` para compatibilidade. Simplificadas as referências de `Microsoft.EntityFrameworkCore.Design` e `Microsoft.EntityFrameworkCore.Tools`. Outras dependências permanecem inalteradas.