### PR TITLE
Mapear dtos de resumo (auto mapper)

### DIFF
--- a/SabidosAPI-Core/DTOs/ResumoCreateUpdateDto.cs
+++ b/SabidosAPI-Core/DTOs/ResumoCreateUpdateDto.cs
@@ -1,0 +1,24 @@
+
+using System.ComponentModel.DataAnnotations;
+
+namespace SabidosAPI_Core.DTOs
+{
+    public class ResumoCreateUpdateDto
+    {
+        [Required]
+        [MaxLength(160)]
+        public string Titulo { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(8000)]
+        public string Conteudo { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(160)]
+        public string AuthorUid { get; set; } = string.Empty;
+
+        [Required]
+        [MaxLength(160)]
+        public string AuthorName { get; set; } = string.Empty;
+    }
+}       

--- a/SabidosAPI-Core/DTOs/ResumoResponseDto.cs
+++ b/SabidosAPI-Core/DTOs/ResumoResponseDto.cs
@@ -4,6 +4,8 @@ namespace SabidosAPI_Core.DTOs
 {
     public class ResumoResponseDto
     {
+            
+        public int Id { get; set; }
         public string Titulo { get; set; } = string.Empty;
         public string Conteudo { get; set; } = string.Empty;
         public string AuthorUid { get; set; } = string.Empty;

--- a/SabidosAPI-Core/Mappings/ResumoProfile.cs
+++ b/SabidosAPI-Core/Mappings/ResumoProfile.cs
@@ -1,0 +1,18 @@
+using AutoMapper;
+using SabidosAPI_Core.Models;
+using SabidosAPI_Core.DTOs;
+
+namespace SabidosAPI_Core.Mappings
+{
+    public class ResumoProfile : Profile
+    {
+        public ResumoProfile()
+        {
+            CreateMap<Resumo, ResumoResponseDto>();
+            CreateMap<ResumoCreateUpdateDto, Resumo>()
+                .ForAllMembers(opts => opts.Condition((src, dest, srcMember) => srcMember != null));
+            CreateMap<Resumo, ResumoCreateUpdateDto>();
+        }
+    }
+}   
+

--- a/SabidosAPI-Core/Models/Resumo.cs
+++ b/SabidosAPI-Core/Models/Resumo.cs
@@ -5,6 +5,9 @@ namespace SabidosAPI_Core.Models
 {
     public class Resumo
     {
+        [Key]
+        public int Id { get; set; }
+
         [Required]
         [MaxLength(160)]
         public string Titulo { get; set; } = string.Empty;

--- a/SabidosAPI-Core/Program.cs
+++ b/SabidosAPI-Core/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 
 // AutoMapper
 builder.Services.AddAutoMapper(typeof(UserProfile));
+builder.Services.AddAutoMapper(typeof(ResumoProfile));
 
 // Services (por favor colocar todos neste grupo)
 builder.Services.AddScoped<UserService>();


### PR DESCRIPTION
Implementada a classe `ResumoProfile` para configurar o AutoMapper, permitindo o mapeamento entre as entidades `Resumo` e os DTOs `ResumoResponseDto` e `ResumoCreateUpdateDto`. Adicionado tratamento para ignorar membros nulos durante a cópia de propriedades. Atualizada a configuração do AutoMapper no `Program.cs` para incluir a nova classe `ResumoProfile`.