### PR TITLE
Mapear Dtos de Evento (AutoMapper) #54

### DIFF
--- a/SabidosAPI-Core/Mappings/EventoProfile.cs
+++ b/SabidosAPI-Core/Mappings/EventoProfile.cs
@@ -1,0 +1,25 @@
+﻿using AutoMapper;
+using SabidosAPI_Core.Models;
+using SabidosAPI_Core.DTOs;
+
+namespace SabidosAPI_Core.Mappings
+{
+    public class EventoProfile : Profile
+    {
+        public EventoProfile()
+        {
+            // Model -> ResponseDto
+            CreateMap<Evento, EventoResponseDto>()
+                .ForMember(dest => dest.Id, opt => opt.MapFrom(src => src.Id.ToString()))
+                .ForMember(dest => dest.TitleEvet, opt => opt.MapFrom(src => src.TitleEvent ?? string.Empty))
+                .ForMember(dest => dest.AuthorUid, opt => opt.MapFrom(src => src.AuthorUid))
+                .ForMember(dest => dest.DataEvento, opt => opt.MapFrom(src => src.DataEvento.HasValue ? src.DataEvento.Value : default));
+
+            // CreateDto -> Model
+            CreateMap<EventoCreateDto, Evento>()
+                .ForMember(dest => dest.TitleEvent, opt => opt.MapFrom(src => src.TitleEvent ?? string.Empty))
+                .ForMember(dest => dest.DataEvento, opt => opt.MapFrom(src => src.DataEvento))
+                .ForMember(dest => dest.AuthorUid, opt => opt.MapFrom(src => src.AuthorUid));
+        }
+    }
+}


### PR DESCRIPTION
Adiciona perfil de mapeamento para Evento com AutoMapper

Implementa mapeamentos entre Evento, EventoResponseDto e EventoCreateDto. Inclui tratamento de valores nulos e conversão de tipos.