### PR TITLE
Config/100 criação da fábrica de testes customwebapplicationfactory

### DIFF
--- a/Api.Tests/Api.Tests.csproj
+++ b/Api.Tests/Api.Tests.csproj
@@ -8,6 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Integration\CustomWebApplicationFactory.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Integration\CustomWebApplicationFactory.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />

--- a/Api.Tests/Api.Tests.csproj
+++ b/Api.Tests/Api.Tests.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SabidosAPI-Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Api.Tests/Api.Tests.sln
+++ b/Api.Tests/Api.Tests.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36401.2 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.Tests", "Api.Tests.csproj", "{B8C89ECD-93E0-8D35-81A0-A12BF2E5FE78}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B8C89ECD-93E0-8D35-81A0-A12BF2E5FE78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8C89ECD-93E0-8D35-81A0-A12BF2E5FE78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8C89ECD-93E0-8D35-81A0-A12BF2E5FE78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8C89ECD-93E0-8D35-81A0-A12BF2E5FE78}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BD0EBD1C-CC96-4A9F-A419-3C50C725E381}
+	EndGlobalSection
+EndGlobal

--- a/Api.Tests/Integration/CustomWebApplicationFactory.cs
+++ b/Api.Tests/Integration/CustomWebApplicationFactory.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using SabidosAPI_Core.Data;
+
+public class CustomWebApplicationFactory<TProgram> : WebApplicationFactory<TProgram> where TProgram : class
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            // Remove a configuração do DbContext de produção
+            var dbContextDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(DbContextOptions<AppDbContext>));
+
+            if (dbContextDescriptor != null)
+            {
+                services.Remove(dbContextDescriptor);
+            }
+
+            // Adiciona um DbContext em memória para os testes
+            services.AddDbContext<AppDbContext>(options =>
+            {
+                options.UseInMemoryDatabase("InMemoryDbForTesting");
+            });
+
+            // Opcional: Desabilita logging para não poluir o console do teste
+            var loggerDescriptor = services.SingleOrDefault(
+                d => d.ServiceType == typeof(ILogger<>));
+
+            if (loggerDescriptor != null)
+            {
+                services.Remove(loggerDescriptor);
+            }
+
+            // Cria um provedor de serviço e cria o banco de dados em memória
+            var sp = services.BuildServiceProvider();
+            using (var scope = sp.CreateScope())
+            {
+                var scopedServices = scope.ServiceProvider;
+                var db = scopedServices.GetRequiredService<AppDbContext>();
+                db.Database.EnsureCreated();
+            }
+        });
+    }
+}

--- a/Api.Tests/UnitTest1.cs
+++ b/Api.Tests/UnitTest1.cs
@@ -1,0 +1,10 @@
+﻿namespace Api.Tests;
+
+public class UnitTest1
+{
+    [Fact]
+    public void Test1()
+    {
+
+    }
+}


### PR DESCRIPTION
Criação da Fábrica de Testes (CustomWebApplicationFactory) #100

- **Estrutura de Teste:**
  - Introdução do `CustomWebApplicationFactory` para criar um ambiente de teste na memória, usando um `DbContext` isolado.
  - Organização dos testes em pastas `/Unit` e `/Integration`.